### PR TITLE
Style checks

### DIFF
--- a/.github/workflows/static.yaml
+++ b/.github/workflows/static.yaml
@@ -1,0 +1,24 @@
+name: Static checks for style
+
+on:
+  push:
+  pull_request:
+    branches: [main, develop]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    name: Style checks
+    steps:
+      # Checkout the code we are testing
+      - uses: actions/checkout@v2
+      # Setup Python
+      - uses: actions/setup-python@v2
+        with:
+          python-version: '3.9'
+      # Install dependencies and package
+      - run: pip install .[tests]
+      # Run linting and style check
+      - run: flake8 src/
+      # Check import order
+      - run: isort --check-only --verbose src/

--- a/setup.cfg
+++ b/setup.cfg
@@ -29,9 +29,16 @@ exclude =
 [options.extras_require]
 tests =
     pytest
+    flake8
+    isort
 
 [options.entry_points]
 console_scripts =
     run_model = hivpy.cli:run_model
     register_parameters = hivpy.cli:register_parameters
 
+[flake8]
+max-line-length = 100
+per-file-ignores =
+    # Don't complain about unused imports in __init__.py
+    */__init__.py: F401

--- a/src/hivpy/__init__.py
+++ b/src/hivpy/__init__.py
@@ -1,3 +1,3 @@
 from .exceptions import SimulationException
 from .experiment import run_experiment
-from .simulation import run_simulation, SimulationConfig
+from .simulation import SimulationConfig, run_simulation

--- a/src/hivpy/cli.py
+++ b/src/hivpy/cli.py
@@ -3,21 +3,24 @@ import argparse
 import pathlib
 from .experiment import create_experiment, run_experiment
 
+
 '''
 Maybe we may want to register parameters/properties in future?
 '''
-def register_parameters():
-    parser = argparse.ArgumentParser(description="register model parameters")
-    parser.add_argument("parameters", type=pathlib.Path, help="register_parameters parameters.csv")
-    args = parser.parse_args()
-    parameter_filepath = args.parameters
+# def register_parameters():
+#     parser = argparse.ArgumentParser(description="register model parameters")
+#     parser.add_argument("parameters", type=pathlib.Path,
+#                         help="register_parameters parameters.csv")
+#     args = parser.parse_args()
+#     parameter_filepath = args.parameters
 
-'''
-Running a HIV model simulation
-Assuming there is a hivpy.conf file the command is
-$run_model hivpy.conf
-'''
+
 def run_model():
+    '''
+    Running a HIV model simulation
+    Assuming there is a hivpy.conf file the command is
+    $run_model hivpy.conf
+    '''
     parser = argparse.ArgumentParser(description="run a simulation")
     parser.add_argument("input", type=pathlib.Path, help="run_model config.conf")
     args = parser.parse_args()

--- a/src/hivpy/cli.py
+++ b/src/hivpy/cli.py
@@ -1,8 +1,8 @@
-import configparser
 import argparse
+import configparser
 import pathlib
-from .experiment import create_experiment, run_experiment
 
+from .experiment import create_experiment, run_experiment
 
 '''
 Maybe we may want to register parameters/properties in future?

--- a/src/hivpy/config.py
+++ b/src/hivpy/config.py
@@ -1,7 +1,8 @@
-from dataclasses import dataclass, field
 import logging
+from dataclasses import dataclass, field
 from datetime import date, timedelta
 from typing import List
+
 from .exceptions import SimulationException
 
 LEVELS = {

--- a/src/hivpy/config.py
+++ b/src/hivpy/config.py
@@ -12,6 +12,7 @@ LEVELS = {
     'CRITICAL': logging.CRITICAL
 }
 
+
 @dataclass
 class OutputConfig:
     output_dir: str
@@ -22,6 +23,7 @@ class OutputConfig:
         logging.basicConfig(filename=self.logfile, level=LEVELS[self.loglevel])
         logging.info("starting experiment")
         print("Starting the simulation. Please, consult the logfile at "+self.logfile)
+
 
 @dataclass
 class SimulationConfig:
@@ -47,6 +49,7 @@ class SimulationConfig:
         """Track an additional attribute during simulation."""
         # TODO Check if already tracked (or conver tracked to a set?)
         self.tracked.append(attribute_name)
+
 
 @dataclass
 class ExperimentConfig:

--- a/src/hivpy/exceptions.py
+++ b/src/hivpy/exceptions.py
@@ -1,5 +1,6 @@
 """Functionality shared between multiple parts of the framework."""
 
+
 class SimulationException(Exception):
     """A class to distinguish exceptions thrown by the hivpy framework."""
     pass

--- a/src/hivpy/experiment.py
+++ b/src/hivpy/experiment.py
@@ -1,7 +1,8 @@
-from datetime import date, timedelta
-from .simulation import run_simulation
-from .config import ExperimentConfig, SimulationConfig, OutputConfig
 import os
+from datetime import date, timedelta
+
+from .config import ExperimentConfig, OutputConfig, SimulationConfig
+from .simulation import run_simulation
 
 
 def create_simulation(experiment_param):

--- a/src/hivpy/experiment.py
+++ b/src/hivpy/experiment.py
@@ -6,10 +6,10 @@ import os
 
 def create_simulation(experiment_param):
     try:
-        start_date = date(int(experiment_param['START_YEAR']),1 ,1 )
-        end_date = date(int(experiment_param['END_YEAR']),12, 31)
+        start_date = date(int(experiment_param['START_YEAR']), 1, 1)
+        end_date = date(int(experiment_param['END_YEAR']), 12, 31)
         population_size = int(experiment_param['POPULATION'])
-        interval = timedelta(days = int(experiment_param['TIME_INTERVAL_DAYS']))
+        interval = timedelta(days=int(experiment_param['TIME_INTERVAL_DAYS']))
         return SimulationConfig(population_size, start_date, end_date, interval)
     except ValueError as err:
         print('Error parsing the experiment parameters {}'.format(err))
@@ -40,3 +40,4 @@ def run_experiment(experiment_config):
     """
     experiment_config.output_config.start_logging()
     result = run_simulation(experiment_config.simulation_config)
+    return result

--- a/src/hivpy/population.py
+++ b/src/hivpy/population.py
@@ -5,6 +5,7 @@ from typing import Callable, Dict
 import numpy as np
 import pandas as pd
 
+
 class Population:
     """A set of individuals with particular characteristics."""
     size: int  # how many individuals to create in total
@@ -25,7 +26,7 @@ class Population:
         """Randomly determine the uncertain population-level parameters."""
         # Example: Each person will have a predetermined max age,
         # which will come from a normal distribution. The mean of
-        # that distrubition is chosen randomly for each population. 
+        # that distrubition is chosen randomly for each population.
         avg_max_age = random.choices([80, 85, 90], [0.4, 0.4, 0.2])
         self.params = {
             'avg_max_age': avg_max_age
@@ -70,7 +71,7 @@ class Population:
         """Advance the population by one time step."""
         # Does nothing just yet except advance the current date, track ages
         # and set death dates.
-        self.data.age += time_step.days / 365 # Very naive!
+        self.data.age += time_step.days / 365  # Very naive!
         # Record who has reached their max age
         died_this_period = self.data.age >= self.data.max_age
         self.data.loc[died_this_period, "date_of_death"] = self.date
@@ -78,4 +79,3 @@ class Population:
         # the population in-place. We will likely need a copy at some point.
         self.date += time_step
         return self
-        

--- a/src/hivpy/simulation.py
+++ b/src/hivpy/simulation.py
@@ -1,9 +1,10 @@
 import logging
+
 import pandas as pd
 
+from .config import SimulationConfig
 from .exceptions import SimulationException
 from .population import Population
-from .config import SimulationConfig
 
 
 class SimulationHandler:

--- a/src/hivpy/simulation.py
+++ b/src/hivpy/simulation.py
@@ -1,4 +1,3 @@
-from dataclasses import dataclass, field
 import logging
 import pandas as pd
 
@@ -7,21 +6,20 @@ from .population import Population
 from .config import SimulationConfig
 
 
-
 class SimulationHandler:
     """A class for handling executing a simulation and accessing results."""
     simulation_config: SimulationConfig
     population: Population
     results: pd.DataFrame
-    
+
     def __init__(self, simulation_config):
         self.simulation_config = simulation_config
         self.results = None
         self._initialise_population()
 
     def _initialise_population(self):
-        self.population = Population(self.simulation_config.population_size, self.simulation_config.start_date)
-
+        self.population = Population(self.simulation_config.population_size,
+                                     self.simulation_config.start_date)
 
     def _validate_tracked(self, population):
         for attribute in self.simulation_config.tracked:
@@ -39,7 +37,7 @@ class SimulationHandler:
         assert date == self.population.date
         time_step = self.simulation_config.time_step
         while date < self.simulation_config.stop_date:
-            logging.info("Timestep %s\n",date)
+            logging.info("Timestep %s\n", date)
             # Advance the population
             self.population = self.population.evolve(time_step)
             date = date + time_step
@@ -54,7 +52,7 @@ class SimulationHandler:
 
 def run_simulation(simulation_config):
     """Run a single simulation for the given population and time bounds.
-    
+
     This is a convenience method to avoid using SimulationHandler directly.
     """
     handler = SimulationHandler(simulation_config)

--- a/src/tests/test_experiment.py
+++ b/src/tests/test_experiment.py
@@ -1,5 +1,5 @@
-from configparser import ConfigParser
 import os.path
+from configparser import ConfigParser
 
 import pytest
 

--- a/src/tests/test_experiment.py
+++ b/src/tests/test_experiment.py
@@ -15,9 +15,10 @@ def sample_experiment_params():
     print(list(parser.items()))
     return parser
 
+
 def test_dummy_workflow(sample_experiment_params):
     """Check that we can run a sample experiment from start to end.
-    
+
     This is only a placeholder test and should be replaced when we have
     implemented actual functionality.
     """

--- a/src/tests/test_simulation.py
+++ b/src/tests/test_simulation.py
@@ -1,8 +1,8 @@
-from datetime import timedelta, date
+from datetime import date, timedelta
 
 import pytest
 
-from hivpy import run_simulation, SimulationConfig, SimulationException
+from hivpy import SimulationConfig, SimulationException, run_simulation
 from hivpy.population import Population
 
 

--- a/src/tests/test_simulation.py
+++ b/src/tests/test_simulation.py
@@ -3,7 +3,6 @@ from datetime import timedelta, date
 import pytest
 
 from hivpy import run_simulation, SimulationConfig, SimulationException
-from hivpy import population
 from hivpy.population import Population
 
 


### PR DESCRIPTION
Fixes #8.

- Use `flake8` for adherence to PEP8 and for linting:
    - Adjust max line length to 100 instead of the default 80 for some more flexibility.
    - Ignore the unused imports in the `__init__.py` as they are only used for "exporting".
    - Have commented out the currently-unused part of `cli.py` so the linting doesn't complain.
- Use `isort` to check the order and separation of import statements.
    - We can run `isort src` locally to automatically format them in future changes.
- Add tools to the "tests" extra options and set up a new Actions workflow for them.