### PR TITLE
Refactor config creation from file

### DIFF
--- a/src/hivpy/cli.py
+++ b/src/hivpy/cli.py
@@ -2,7 +2,8 @@ import argparse
 import configparser
 import pathlib
 
-from .experiment import create_experiment, run_experiment
+from .config import ExperimentConfig
+from .experiment import run_experiment
 
 '''
 Maybe we may want to register parameters/properties in future?
@@ -28,7 +29,7 @@ def run_model():
     config = configparser.ConfigParser()
     try:
         config.read(conf_filename)
-        experiment_config = create_experiment(config)
+        experiment_config = ExperimentConfig.from_file(config)
         run_experiment(experiment_config)
 
     except configparser.Error as err:

--- a/src/hivpy/cli.py
+++ b/src/hivpy/cli.py
@@ -1,8 +1,8 @@
 import argparse
-import configparser
 import pathlib
 
 from .config import ExperimentConfig
+from .exceptions import ConfigException
 from .experiment import run_experiment
 
 '''
@@ -26,14 +26,11 @@ def run_model():
     parser.add_argument("input", type=pathlib.Path, help="run_model config.conf")
     args = parser.parse_args()
     conf_filename = args.input
-    config = configparser.ConfigParser()
     try:
-        config.read(conf_filename)
-        experiment_config = ExperimentConfig.from_file(config)
+        experiment_config = ExperimentConfig.from_file(conf_filename)
         run_experiment(experiment_config)
-
-    except configparser.Error as err:
-        print('error parsing the config file {}'.format(err))
+    except ConfigException as err:
+        print(err.args[0])
 
 
 if __name__ == '__main__':

--- a/src/hivpy/config.py
+++ b/src/hivpy/config.py
@@ -1,10 +1,11 @@
+import configparser
 import logging
 import os
 from dataclasses import dataclass, field
 from datetime import date, timedelta
 from typing import List
 
-from .exceptions import SimulationException
+from .exceptions import ConfigException, SimulationException
 
 LEVELS = {
     'DEBUG': logging.DEBUG,
@@ -82,8 +83,13 @@ class ExperimentConfig:
     output_config: OutputConfig
 
     @classmethod
-    def from_file(cls, file_config):
+    def from_file(cls, filename):
         """Create a configuration from the contents of a file."""
+        file_config = configparser.ConfigParser()
+        try:
+            file_config.read(filename)
+        except configparser.Error as err:
+            raise ConfigException(f'Error parsing the config file: {err}')
         simulation_config = SimulationConfig.from_file(file_config['EXPERIMENT'])
         output_config = OutputConfig.from_file(file_config['OUTPUT'])
         return cls(simulation_config, output_config)

--- a/src/hivpy/config.py
+++ b/src/hivpy/config.py
@@ -80,3 +80,10 @@ class SimulationConfig:
 class ExperimentConfig:
     simulation_config: SimulationConfig
     output_config: OutputConfig
+
+    @classmethod
+    def from_file(cls, file_config):
+        """Create a configuration from the contents of a file."""
+        simulation_config = SimulationConfig.from_file(file_config['EXPERIMENT'])
+        output_config = OutputConfig.from_file(file_config['OUTPUT'])
+        return cls(simulation_config, output_config)

--- a/src/hivpy/exceptions.py
+++ b/src/hivpy/exceptions.py
@@ -4,3 +4,8 @@
 class SimulationException(Exception):
     """A class to distinguish exceptions thrown by the hivpy framework."""
     pass
+
+
+class ConfigException(Exception):
+    """A class to indicate errors related to reading config files."""
+    pass

--- a/src/hivpy/experiment.py
+++ b/src/hivpy/experiment.py
@@ -1,11 +1,4 @@
-from .config import ExperimentConfig, OutputConfig, SimulationConfig
 from .simulation import run_simulation
-
-
-def create_experiment(all_params):
-    simulation_config = SimulationConfig.from_file(all_params['EXPERIMENT'])
-    output_config = OutputConfig.from_file(all_params['OUTPUT'])
-    return ExperimentConfig(simulation_config, output_config)
 
 
 def run_experiment(experiment_config):

--- a/src/hivpy/experiment.py
+++ b/src/hivpy/experiment.py
@@ -1,35 +1,10 @@
-import os
-from datetime import date, timedelta
-
 from .config import ExperimentConfig, OutputConfig, SimulationConfig
 from .simulation import run_simulation
 
 
-def create_simulation(experiment_param):
-    try:
-        start_date = date(int(experiment_param['START_YEAR']), 1, 1)
-        end_date = date(int(experiment_param['END_YEAR']), 12, 31)
-        population_size = int(experiment_param['POPULATION'])
-        interval = timedelta(days=int(experiment_param['TIME_INTERVAL_DAYS']))
-        return SimulationConfig(population_size, start_date, end_date, interval)
-    except ValueError as err:
-        print('Error parsing the experiment parameters {}'.format(err))
-    except KeyError as kerr:
-        print('Error extracting values from the parameter set {}'.format(kerr))
-    return None
-
-
-def create_output(output_param):
-    outputdir = output_param['OUTPUT_DIRECTORY']
-    logfilename = output_param['LOGOUTPUT_NAME']
-    log_level = output_param['LOG_LEVEL']
-    logpath = os.path.join(outputdir, logfilename)
-    return OutputConfig(outputdir, logpath, log_level)
-
-
 def create_experiment(all_params):
-    simulation_config = create_simulation(all_params['EXPERIMENT'])
-    output_config = create_output(all_params['OUTPUT'])
+    simulation_config = SimulationConfig.from_file(all_params['EXPERIMENT'])
+    output_config = OutputConfig.from_file(all_params['OUTPUT'])
     return ExperimentConfig(simulation_config, output_config)
 
 

--- a/src/tests/test_experiment.py
+++ b/src/tests/test_experiment.py
@@ -1,26 +1,23 @@
 import os.path
-from configparser import ConfigParser
 
 import pytest
 
-from hivpy.experiment import create_experiment, run_experiment
+from hivpy.config import ExperimentConfig
+from hivpy.experiment import run_experiment
 
 
 @pytest.fixture
-def sample_experiment_params():
+def sample_config_file():
     """Sample experiment parameters for testing."""
-    parser = ConfigParser()
-    parser.read(
-        os.path.join(os.path.dirname(__file__), 'fixtures', 'sample.conf'))
-    print(list(parser.items()))
-    return parser
+    config_file = os.path.join(os.path.dirname(__file__), 'fixtures', 'sample.conf')
+    return config_file
 
 
-def test_dummy_workflow(sample_experiment_params):
+def test_dummy_workflow(sample_config_file):
     """Check that we can run a sample experiment from start to end.
 
     This is only a placeholder test and should be replaced when we have
     implemented actual functionality.
     """
-    dummy_config = create_experiment(sample_experiment_params)
+    dummy_config = ExperimentConfig.from_file(sample_config_file)
     run_experiment(dummy_config)


### PR DESCRIPTION
Fixes #14.

Moving some things around. This should also make it easier if we want to change the format of the config file.

I wonder if it would be better for each config to live in the corresponding module, e.g. `SimulationConfig` in `simulation.py` along with the simulation handler, etc.