### PR TITLE
Switch to newer-style RNG calls

### DIFF
--- a/src/hivpy/common.py
+++ b/src/hivpy/common.py
@@ -47,7 +47,20 @@ def between(values, limits):
 
 
 class ResettableRandomState:
+    """A convenience class for using the NumPy random number generator.
+
+    This is meant to be used as: `from hivpy.common import rng`
+
+    For most things, this can be used exactly as NumPy's `Generator`. All the
+    methods like `random`, `normal`, `choice` are supported and called in
+    exactly the same way.
+
+    The primary purpose of this is to share the `Generator` across multiple files,
+    while allowing anyone to set the seed, whether in tests or the main code.
+    It also offers the ability to use a temporary seed.
+    """
     def __init__(self):
+        """Create a new wrapper around a NumPy Generator."""
         self.rng = np.random.default_rng()
 
     def __getattr__(self, name):
@@ -72,9 +85,10 @@ class ResettableRandomState:
         forget about it.
 
         The temporary seed can be used in a with-statement, like:
-        with rng.set_temp_seed(n):
-            rng.random(...)
-
+        ```
+        with rng.set_temp_seed(17):
+            rng.random(...)  # any calls to random methods here
+        ```
         When the with-block is ended, the old random state is restored, as if
         the temporary seed had never been set.
         """

--- a/src/hivpy/common.py
+++ b/src/hivpy/common.py
@@ -45,6 +45,22 @@ def between(values, limits):
     # return _is_in_range
 
 
+class ResettableRandomState:
+    def __init__(self):
+        self.rng = np.random.default_rng()
+
+    def __getattr__(self, name):
+        """Delegate method calls and attribute lookups to the Generator."""
+        return getattr(self.rng, name)
+
+    def set_seed(self, seed):
+        """Set the seed that controls the sequence of values generated.
+
+        Generating samples from the same seed should always return the same
+        results.
+        """
+        self.rng = np.random.default_rng(seed)
+
 # A shared random number generator to be used from different modules.
 # Will be initialised at first import.
-rng = np.random.default_rng()
+rng = ResettableRandomState()

--- a/src/hivpy/common.py
+++ b/src/hivpy/common.py
@@ -43,3 +43,8 @@ def between(values, limits):
     # def _is_in_range(values):
     return (min_value <= values) & (values < max_value)
     # return _is_in_range
+
+
+# A shared random number generator to be used from different modules.
+# Will be initialised at first import.
+rng = np.random.default_rng()

--- a/src/hivpy/demographics.py
+++ b/src/hivpy/demographics.py
@@ -223,7 +223,7 @@ class DemographicsModule:
 
     def initialize_sex(self, count):
         sex_distribution = (
-            self.params['female_ratio'], 1 - self.params['female_ratio'])
+            1 - self.params['female_ratio'], self.params['female_ratio'])
         return pd.Series(rng.choice(SexType, count, p=sex_distribution)).astype(SexDType)
 
     def initialise_age(self, count):

--- a/src/hivpy/demographics.py
+++ b/src/hivpy/demographics.py
@@ -6,7 +6,7 @@ import numpy as np
 import pandas as pd
 from scipy.interpolate import interp1d
 
-from hivpy.common import SexType, between, selector
+from hivpy.common import SexType, between, rng, selector
 from hivpy.exceptions import SimulationException
 
 SexDType = pd.CategoricalDtype(iter(SexType))
@@ -111,7 +111,7 @@ class StepwiseAgeDistribution:
         """
         cpd = self._gen_cumulative_prob()
         p0 = 0.0
-        rands = np.random.rand(N)
+        rands = rng.random(N)
         ages_out = np.zeros(N)
         for i in range(0, cpd.size):
             # in order to vectorise this method we create a mask of values
@@ -199,7 +199,7 @@ class ContinuousAgeDistribution:
         NormInv = interp1d(NormY, NormX, kind='cubic')
 
         # generate N random numbers in (0,1) and convert to ages
-        R = np.random.rand(N)
+        R = rng.random(N)
         Ages = NormInv(R)
         return Ages
 
@@ -224,7 +224,7 @@ class DemographicsModule:
     def initialize_sex(self, count):
         sex_distribution = (
             self.params['female_ratio'], 1 - self.params['female_ratio'])
-        return pd.Series(np.random.choice(SexType, count, sex_distribution)).astype(SexDType)
+        return pd.Series(rng.choice(SexType, count, p=sex_distribution)).astype(SexDType)
 
     def initialise_age(self, count):
         if(self.params['use_stepwise_ages'] is True):
@@ -245,8 +245,8 @@ class DemographicsModule:
                 group = population_data[index]
                 # Probability of dying, assuming time step of 3 months
                 prob_of_death = 1 - exp(-rate / 4)
-                died = np.random.choice([True, False], size=len(group),
-                                        p=[prob_of_death, 1 - prob_of_death])
+                died = rng.choice([True, False], size=len(group),
+                                  p=[prob_of_death, 1 - prob_of_death])
                 # Mark those who died from this group
                 all_died |= pd.Series(died, index=group.index)
         return population_data.date_of_death.isnull() & all_died
@@ -266,5 +266,5 @@ class DemographicsModule:
             prob_of_death = 1 - exp(-rate / 4)
             death_probs[entries] = prob_of_death
             # Mark those who died from this group and sex
-        rands = np.random.random_sample(len(population_data))
+        rands = rng.random(len(population_data))
         return population_data.date_of_death.isnull() & (rands < death_probs)

--- a/src/hivpy/hiv_status.py
+++ b/src/hivpy/hiv_status.py
@@ -3,6 +3,7 @@ import operator
 import numpy as np
 import pandas as pd
 
+from .common import rng
 from .sexual_behaviour import selector
 
 
@@ -18,7 +19,7 @@ class HIVStatusModule:
     def initial_HIV_status(self, population: pd.DataFrame):
         """Initialise HIV status based on age (& sex?)"""
         """Assume zero prevalence for age < 15"""
-        hiv_status = self._prob_HIV_initial(population["age"]) > np.random.rand(len(population))
+        hiv_status = self._prob_HIV_initial(population["age"]) > rng.random(len(population))
         return hiv_status
 
     def update_HIV_status(self, population: pd.DataFrame):
@@ -29,7 +30,7 @@ class HIVStatusModule:
             Then prob of n partners independently not infecting you is (1-Pr)**n\\
             So probability of infection is 1-((1-Pr)**n)"""
         HIV_neg_idx = selector(population, HIV_status=(operator.eq, False))
-        rands = np.random.uniform(0.0, 1.0, sum(HIV_neg_idx))
+        rands = rng.uniform(0.0, 1.0, sum(HIV_neg_idx))
         HIV_prevalence = sum(population['HIV_status'])/len(population)
         HIV_infection_risk = 0.1  # made up, based loosely on transmission probabilities
         n_partners = population.loc[HIV_neg_idx, "num_partners"]

--- a/src/hivpy/sex_behaviour_data.py
+++ b/src/hivpy/sex_behaviour_data.py
@@ -47,9 +47,6 @@ class SexualBehaviourData:
             for key, data in prob_dict.items()
         }
 
-    def _select_matrix(self, matrix_list):
-        return rng.choice(matrix_list)
-
     def __init__(self, filename):
         with open(filename, 'r') as file:
             self.data = yaml.safe_load(file)
@@ -67,7 +64,7 @@ class SexualBehaviourData:
                 "short_term_partner_distributions", "Sex_Worker")
 
             self.age_based_risk = np.array(
-                self._select_matrix(self.data["age_based_risk_options"]["risk_factor"]))
+                rng.choice(self.data["age_based_risk_options"]["risk_factor"]))
 
             self.sex_behaviour_transition_options = self.data["sex_behaviour_transition_options"]
 

--- a/src/hivpy/sex_behaviour_data.py
+++ b/src/hivpy/sex_behaviour_data.py
@@ -3,7 +3,7 @@ import yaml
 
 from hivpy.exceptions import DataLoadException
 
-from .common import DiscreteChoice, SexType
+from .common import DiscreteChoice, SexType, rng
 
 
 class SexualBehaviourData:
@@ -48,7 +48,7 @@ class SexualBehaviourData:
         }
 
     def _select_matrix(self, matrix_list):
-        return matrix_list[np.random.choice(len(matrix_list))]
+        return matrix_list[rng.choice(len(matrix_list))]
 
     def __init__(self, filename):
         with open(filename, 'r') as file:

--- a/src/hivpy/sex_behaviour_data.py
+++ b/src/hivpy/sex_behaviour_data.py
@@ -48,7 +48,7 @@ class SexualBehaviourData:
         }
 
     def _select_matrix(self, matrix_list):
-        return matrix_list[rng.choice(len(matrix_list))]
+        return rng.choice(matrix_list)
 
     def __init__(self, filename):
         with open(filename, 'r') as file:

--- a/src/hivpy/sexual_behaviour.py
+++ b/src/hivpy/sexual_behaviour.py
@@ -25,9 +25,6 @@ SexBehaviours = {SexType.Male: MaleSexBehaviour, SexType.Female: FemaleSexBehavi
 
 class SexualBehaviourModule:
 
-    def select_matrix(self, matrix_list):
-        return rng.choice(matrix_list)
-
     def __init__(self, **kwargs):
         # init sexual behaviour data
         self.sb_data = SexualBehaviourData("data/sex_behaviour.yaml")
@@ -35,9 +32,9 @@ class SexualBehaviourModule:
         # Randomly initialise sexual behaviour group transitions
         self.sex_behaviour_trans = {
             SexType.Male: np.array(
-                self.select_matrix(self.sb_data.sex_behaviour_transition_options["Male"])),
+                rng.choice(self.sb_data.sex_behaviour_transition_options["Male"])),
             SexType.Female: np.array(
-                self.select_matrix(self.sb_data.sex_behaviour_transition_options["Female"]))
+                rng.choice(self.sb_data.sex_behaviour_transition_options["Female"]))
         }
         self.init_sex_behaviour_probs = self.sb_data.init_sex_behaviour_probs
         self.age_based_risk = self.sb_data.age_based_risk
@@ -45,8 +42,8 @@ class SexualBehaviourModule:
         self.risk_min_age = 15  # This should come out of config somewhere
         self.risk_age_grouping = 5  # ditto
         self.sex_mixing_matrix = {
-            SexType.Male: self.select_matrix(self.sb_data.sex_mixing_matrix_male_options),
-            SexType.Female: self.select_matrix(self.sb_data.sex_mixing_matrix_female_options)
+            SexType.Male: rng.choice(self.sb_data.sex_mixing_matrix_male_options),
+            SexType.Female: rng.choice(self.sb_data.sex_mixing_matrix_female_options)
         }
         self.short_term_partners = {SexType.Male: self.sb_data.male_stp_dists,
                                     SexType.Female: self.sb_data.female_stp_u25_dists}

--- a/src/hivpy/sexual_behaviour.py
+++ b/src/hivpy/sexual_behaviour.py
@@ -4,7 +4,7 @@ from enum import IntEnum
 import numpy as np
 import pandas as pd
 
-from .common import SexType, selector
+from .common import SexType, rng, selector
 from .sex_behaviour_data import SexualBehaviourData
 
 
@@ -26,7 +26,7 @@ SexBehaviours = {SexType.Male: MaleSexBehaviour, SexType.Female: FemaleSexBehavi
 class SexualBehaviourModule:
 
     def select_matrix(self, matrix_list):
-        return matrix_list[np.random.choice(len(matrix_list))]
+        return matrix_list[rng.choice(len(matrix_list))]
 
     def __init__(self, **kwargs):
         # init sexual behaviour data
@@ -81,7 +81,7 @@ class SexualBehaviourModule:
     def init_rred_personal(self, population, n_pop):
         p_rred_p = self.sb_data.p_rred_p_dist.sample(size=len(population))
         population["rred_personal"] = np.ones(n_pop)
-        r = np.random.uniform(size=n_pop)
+        r = rng.uniform(size=n_pop)
         mask = r < p_rred_p
         population.loc[mask, "rred_personal"] = 1e-5
 
@@ -120,7 +120,7 @@ class SexualBehaviourModule:
                     operator.eq, prev_group), age=(operator.ge, 15))
                 if any(index):
                     subpop_size = sum(index)
-                    rands = np.random.uniform(0.0, 1.0, subpop_size)
+                    rands = rng.uniform(0.0, 1.0, subpop_size)
                     self.calc_rred_age(population, index)
                     rred = population.loc[index, "rred"] * population.loc[index, "rred_age"]
                     dim = self.sex_behaviour_trans[sex].shape[0]

--- a/src/hivpy/sexual_behaviour.py
+++ b/src/hivpy/sexual_behaviour.py
@@ -26,7 +26,7 @@ SexBehaviours = {SexType.Male: MaleSexBehaviour, SexType.Female: FemaleSexBehavi
 class SexualBehaviourModule:
 
     def select_matrix(self, matrix_list):
-        return matrix_list[rng.choice(len(matrix_list))]
+        return rng.choice(matrix_list)
 
     def __init__(self, **kwargs):
         # init sexual behaviour data

--- a/src/tests/test_demographics.py
+++ b/src/tests/test_demographics.py
@@ -25,7 +25,7 @@ def test_sex_distribution(default_module):
     count = 100000
     sex = default_module.initialize_sex(count)
     female = np.sum(sex == SexType.Female)
-    assert pytest.approx(female/count, rel=0.05) == FEMALE_RATIO
+    assert pytest.approx(female/count, rel=0.01) == FEMALE_RATIO
 
 
 def test_continuous_age_distribution(default_module):

--- a/src/tests/test_random.py
+++ b/src/tests/test_random.py
@@ -1,0 +1,49 @@
+import numpy as np
+
+from hivpy.common import rng
+
+
+def test_seed_reproduce():
+    """Check that using the same seed value produces the same random values."""
+    sample_size = 10
+    # Get samples with a specific seed
+    rng.set_seed(50)
+    samples1 = rng.random(size=sample_size)
+    # Do the same with a different seed, and repeat with the first
+    rng.set_seed(42)
+    samples2 = rng.random(size=sample_size)
+    rng.set_seed(50)
+    samples3 = rng.random(size=sample_size)
+    # The first and last set of samples should be the identical...
+    assert all(samples1 == samples3)
+    # ...but the second should be different
+    assert not all(samples1 == samples2)
+
+
+def test_seed_context():
+    """Check that the context manager sets the seed correctly."""
+    sample_size = 10
+    # Get samples with a particular seed
+    rng.set_seed(50)
+    samples_base = rng.random(size=sample_size)
+    # Get the same from a temporary context; they should be the same
+    with rng.set_temp_seed(50):
+        samples_context = rng.random(size=sample_size)
+    assert all(samples_context == samples_base)
+
+
+def test_seed_context_switching():
+    """Check that the right state is restored after exiting a context."""
+    sample_size = 10
+    rng.set_seed(50)
+    samples_base = rng.random(size=2*sample_size)
+    # Reset the seed. Get some samples
+    rng.set_seed(50)
+    samples_partial1 = rng.random(size=sample_size)
+    # Interrupt with a temporary, different seed
+    with rng.set_temp_seed(42):
+        _ = rng.random(size=sample_size)
+    # Get some more samples from the initial seed
+    samples_partial2 = rng.random(size=sample_size)
+    # Check that the interruption had no effect
+    assert all(samples_base == np.concatenate((samples_partial1, samples_partial2)))

--- a/src/tests/test_random.py
+++ b/src/tests/test_random.py
@@ -42,8 +42,10 @@ def test_seed_context_switching():
     samples_partial1 = rng.random(size=sample_size)
     # Interrupt with a temporary, different seed
     with rng.set_temp_seed(42):
-        _ = rng.random(size=sample_size)
+        samples_temp = rng.random(size=sample_size)
     # Get some more samples from the initial seed
     samples_partial2 = rng.random(size=sample_size)
     # Check that the interruption had no effect
     assert all(samples_base == np.concatenate((samples_partial1, samples_partial2)))
+    # And also that the temporary seed produced different values
+    assert not all(samples_temp == samples_partial2)

--- a/src/tests/test_random.py
+++ b/src/tests/test_random.py
@@ -21,7 +21,7 @@ def test_seed_reproduce():
 
 
 def test_seed_context():
-    """Check that the context manager sets the seed correctly."""
+    """Check that setting the temporary seed has the correct effect."""
     sample_size = 10
     # Get samples with a particular seed
     rng.set_seed(50)
@@ -33,7 +33,7 @@ def test_seed_context():
 
 
 def test_seed_context_switching():
-    """Check that the right state is restored after exiting a context."""
+    """Check that the right state is restored after using a temporary seed."""
     sample_size = 10
     rng.set_seed(50)
     samples_base = rng.random(size=2*sample_size)


### PR DESCRIPTION
Addressing #39.

- Move away from the legacy, shared-state `np.random.*` functions to the newer `Generator` API.
- This also lets us simplify some calls that were [previously discussed](https://github.com/UCL/hivpy/pull/35#discussion_r839645794). Is it still worth keeping the `select_matrix` function in `SexualBehaviourModule`?
- Also fix a bug with the distribution of sexes that became apparent while making the changes.

With the new format, everything shares the same `Generator`, which is initialised and imported from `hivpy.common`. One downside is that we can't set the seed as easily as before, although in the unit tests we can get around that by monkey-patching the shared `rng` object. Another option is to have a very simple wrapper around the generator, with a method for (re)setting the seed. At the moment we never use this in the tests, so I wasn't sure whether to add that in this PR or only later when we need it.