### PR TITLE
Refactor transforms

### DIFF
--- a/src/hivpy/common.py
+++ b/src/hivpy/common.py
@@ -47,17 +47,6 @@ def selector(population, **kwargs):
     return index
 
 
-def transform_group(df, param_list, func, use_size=True):
-    """Groups the data by a list of parameters and applies a function to each grouping"""
-    # HIV_STATUS is just a dummy column to allow us to use the transform method
-    def general_func(g):
-        args = [n for n in g.name] # list(g.name)
-        if(use_size):
-            args.append(g.size)
-        return func(*args)
-    return df.groupby(param_list)[col.HIV_STATUS].transform(general_func)
-
-
 def between(values, limits):
     """A helper function for selecting values within a range."""
     min_value, max_value = limits

--- a/src/hivpy/demographics.py
+++ b/src/hivpy/demographics.py
@@ -7,7 +7,7 @@ import pandas as pd
 from scipy.interpolate import interp1d
 
 import hivpy.column_names as col
-from hivpy.common import SexType, rng, transform_group
+from hivpy.common import SexType, rng
 from hivpy.demographics_data import DemographicsData
 from hivpy.exceptions import SimulationException
 
@@ -201,14 +201,14 @@ class DemographicsModule:
         prob_of_death = 1 - exp(-rate / 4)
         return prob_of_death
 
-    def determine_deaths(self, pop_data: pd.DataFrame) -> pd.Series:
+    def determine_deaths(self, pop) -> pd.Series:
         """Get which individuals die in a time step, as a boolean Series."""
         # This binning should perhaps happen when the date advances
         # Age groups are the same regardless of sex
         age_limits = self.data.death_age_limits
-        pop_data[col.AGE_GROUP] = np.digitize(pop_data[col.AGE], age_limits)
+        pop.data[col.AGE_GROUP] = np.digitize(pop.data[col.AGE], age_limits)
 
-        death_probs = transform_group(pop_data, [col.SEX, col.AGE_GROUP],
-                                      self._probability_of_death, use_size=False)
-        rands = rng.random(len(pop_data))
-        return pop_data.date_of_death.isnull() & (rands < death_probs)
+        death_probs = pop.transform_group([col.SEX, col.AGE_GROUP],
+                                          self._probability_of_death, use_size=False)
+        rands = rng.random(len(pop.data))
+        return pop.data.date_of_death.isnull() & (rands < death_probs)

--- a/src/hivpy/population.py
+++ b/src/hivpy/population.py
@@ -87,6 +87,16 @@ class Population:
         """Get the value of the named attribute at the current date."""
         return self.attributes[attribute_name](self.data)
 
+    def transform_group(self, param_list, func, use_size=True):
+        """Groups the data by a list of parameters and applies a function to each grouping"""
+        # HIV_STATUS is just a dummy column to allow us to use the transform method
+        def general_func(g):
+            args = [n for n in g.name] # list(g.name)
+            if(use_size):
+                args.append(g.size)
+            return func(*args)
+        return self.data.groupby(param_list)[col.HIV_STATUS].transform(general_func)
+
     def evolve(self, time_step: datetime.timedelta):
         """Advance the population by one time step."""
         # Does nothing just yet except advance the current date, track ages

--- a/src/hivpy/population.py
+++ b/src/hivpy/population.py
@@ -1,11 +1,9 @@
 import datetime
-import functools
 
 import pandas as pd
 
 import hivpy.column_names as col
 
-from .common import SexType
 from .demographics import DemographicsModule
 from .hiv_status import HIVStatusModule
 from .sexual_behaviour import SexualBehaviourModule
@@ -54,35 +52,6 @@ class Population:
         self.sexual_behaviour.init_sex_behaviour_groups(self.data)
         self.sexual_behaviour.init_risk_factors(self.data)
         self.sexual_behaviour.num_short_term_partners(self)
-
-    def _create_attributes(self):
-        """Determine what aggregate measures can be computed and how."""
-        attributes = {}
-
-        # Helper functions
-        def count_alive(population_data):
-            """Count how many people don't have a set date of death yet."""
-            return self.size - population_data.date_of_death.count()
-
-        def count_sex_alive(population_data, sex):
-            """Count how many people of the given sex are alive."""
-            assert sex in SexType
-            # Should also make sure they are alive! (always true for now)
-            alive = population_data.date_of_death is not None
-            return population_data[alive].sex.value_counts()[sex]
-
-        attributes["num_alive"] = count_alive
-        attributes["num_male"] = functools.partial(count_sex_alive, sex="male")
-        attributes["num_female"] = functools.partial(count_sex_alive, sex="female")
-        self.attributes = attributes
-
-    def has_attribute(self, attribute_name):
-        """Return whether the named attribute exists in the population."""
-        return attribute_name in self.attributes
-
-    def get(self, attribute_name):
-        """Get the value of the named attribute at the current date."""
-        return self.attributes[attribute_name](self.data)
 
     def transform_group(self, param_list, func, use_size=True, **kwargs):
         """Groups the data by a list of parameters and applies a function to each grouping"""

--- a/src/hivpy/population.py
+++ b/src/hivpy/population.py
@@ -53,16 +53,26 @@ class Population:
         self.sexual_behaviour.init_risk_factors(self.data)
         self.sexual_behaviour.num_short_term_partners(self)
 
-    def transform_group(self, param_list, func, use_size=True, **kwargs):
-        """Groups the data by a list of parameters and applies a function to each grouping"""
+    def transform_group(self, param_list, func, use_size=True, sub_pop=None):
+        """Groups the data by a list of parameters and applies a function to each grouping. \n
+        `param_list` is a list of names of columns by which you want to group the data. The order
+        must match the order of arguments taken by the function `func` \n
+        `func` is a function which takes the values of those columns for a group (and optionally
+        the size of the group, which should be the last argument) and returns a value or array of
+        values of the size of the group. \n
+        `use_size` is true by default, but should be set to false if `func` does not take the size
+        of the group as an argument. \n
+        `sub_pop` is `None` by default, in which case the transform acts upon the entire dataframe.
+        If `sub_pop` is defined, then it acts only on the part of the dataframe defined
+        by `data.loc[sub_pop]`"""
         # HIV_STATUS is just a dummy column to allow us to use the transform method
         def general_func(g):
             args = list(g.name)
             if (use_size):
                 args.append(g.size)
             return func(*args)
-        if "sub_pop" in kwargs.keys():
-            df = self.data.loc[kwargs["sub_pop"]]
+        if sub_pop is not None:
+            df = self.data.loc[sub_pop]
         else:
             df = self.data
         return df.groupby(param_list)[col.HIV_STATUS].transform(general_func)

--- a/src/tests/test_demographics.py
+++ b/src/tests/test_demographics.py
@@ -74,7 +74,7 @@ def test_date_permanent(default_module):
     pop.data['age'] = [30, 20, 50]
     pop.data['sex'] = [SexType.Female, SexType.Female, SexType.Male]
 
-    new_deaths = default_module.determine_deaths(pop.data)
+    new_deaths = default_module.determine_deaths(pop)
     # Find who already had a date of death, and check that they are not marked
     # as having died in this time step.
     assert not new_deaths[pop.data.date_of_death.notnull()].any()
@@ -106,7 +106,7 @@ def test_death_rate():
     # Simulate for a year
     n_steps = 4  # currently death determination assumes 3-month step
     for _ in range(n_steps):
-        deaths = module.determine_deaths(pop.data)
+        deaths = module.determine_deaths(pop)
         # We only care about recording the death here, not its date
         pop.data.loc[deaths, "date_of_death"] = datetime.today()
     recorded_deaths = pop.data.groupby(

--- a/src/tests/test_sexual_behaviour.py
+++ b/src/tests/test_sexual_behaviour.py
@@ -1,6 +1,6 @@
 import importlib.resources
 import operator
-import time
+# import time
 from datetime import date, timedelta
 
 import numpy as np
@@ -59,7 +59,7 @@ def test_sex_behaviour_transition(yaml_data):
     for s in SexType:
         for g in SexBehaviours[s]:
             pop.data.loc[pop.data[col.SEX] == s, col.SEX_BEHAVIOUR] = g
-            pop.sexual_behaviour.update_sex_groups(pop.data)
+            pop.sexual_behaviour.update_sex_groups(pop)
             for g2 in SexBehaviours[s]:
                 num = len(pop.data[(pop.data[col.SEX_BEHAVIOUR] == g2) & (pop.data[col.SEX] == s)])
                 p = trans_matrix[s][g][g2] / (sum(trans_matrix[s][g]))
@@ -94,11 +94,11 @@ def check_num_partners(row):
 def test_num_partners():
     """Check that number of partners are reasonable"""
     pop = Population(size=100000, start_date=date(1989, 1, 1))
-    t1 = time.perf_counter()
-    for x in range(0, 500):
-        pop.sexual_behaviour.num_short_term_partners(pop.data)
-    t2 = time.perf_counter()
-    #print("Time for iterations = ", t2-t1)
+    # t1 = time.perf_counter()
+    # for x in range(0, 500):
+    pop.sexual_behaviour.num_short_term_partners(pop)
+    # t2 = time.perf_counter()
+    # print("Time for iterations = ", t2-t1)
     assert(any(pop.data["num_partners"] > 0))
     # Check the num_partners column
     checks = pop.data.apply(check_num_partners, axis=1)
@@ -110,7 +110,7 @@ def test_behaviour_updates():
     pop = Population(size=1000, start_date=date(1989, 1, 1))
     initial_groupings = pop.data["sex_behaviour"].copy()
     for i in range(500):
-        pop.sexual_behaviour.update_sex_groups(pop.data)
+        pop.sexual_behaviour.update_sex_groups(pop)
     subsequent_groupings = pop.data["sex_behaviour"]
     assert(any(initial_groupings != subsequent_groupings))
 


### PR DESCRIPTION
Move transforms into the population class. (Builds on some work from population-transforms branch.) 

Had to add **kwards to transform_group in order to accommodate acting on sub-populations, although there may be a better way to do this. 

The code can be a little confusing the way it's currently done because Population class can't be imported into SexualBehaviour or Demographics modules due to circular reference, which isn't ideal. Could be sorted out by moving those modules into the simulation and letting them operate on the population class instead of being part of the population class. 