### PR TITLE
Introduce HIV into the population

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -34,6 +34,7 @@ hivpy.data = *.yaml
 [options.extras_require]
 tests =
     pytest
+    pytest-mock
     flake8
     isort
 

--- a/src/hivpy/hiv_status.py
+++ b/src/hivpy/hiv_status.py
@@ -39,7 +39,7 @@ class HIVStatusModule:
         HIV_neg_idx = selector(population, HIV_status=(operator.eq, False))
         rands = rng.uniform(0.0, 1.0, sum(HIV_neg_idx))
         HIV_prevalence = sum(population[col.HIV_STATUS])/len(population)
-        HIV_infection_risk = 0.1  # made up, based loosely on transmission probabilities
+        HIV_infection_risk = 0.2  # made up, based loosely on transmission probabilities
         n_partners = population.loc[HIV_neg_idx, col.NUM_PARTNERS]
         HIV_prob = 1-((1-HIV_prevalence*HIV_infection_risk)**n_partners)
         population.loc[HIV_neg_idx, col.HIV_STATUS] = (rands <= HIV_prob)

--- a/src/hivpy/population.py
+++ b/src/hivpy/population.py
@@ -58,6 +58,10 @@ class Population:
         self.sexual_behaviour.init_sex_behaviour_groups(self.data)
         self.sexual_behaviour.init_risk_factors(self.data)
         self.sexual_behaviour.num_short_term_partners(self)
+        # If we are at the start of the epidemic, introduce HIV into the population.
+        if self.date >= HIV_APPEARANCE and not self.HIV_introduced:
+            self.data[col.HIV_STATUS] = self.hiv_status.introduce_HIV(self.data)
+            self.HIV_introduced = True
 
     def transform_group(self, param_list, func, use_size=True, sub_pop=None):
         """Groups the data by a list of parameters and applies a function to each grouping. \n

--- a/src/tests/test_hiv_status.py
+++ b/src/tests/test_hiv_status.py
@@ -50,7 +50,7 @@ def test_initial_hiv_probability():
     assert initial_status.sum() == pytest.approx(expected_infections, rel=0.05)
 
 
-def test_HIV_introduced_only_once(mocker):
+def test_hiv_introduced_only_once(mocker):
     """Check that we do not initialise HIV status repeatedly."""
     pop = Population(size=1000, start_date=date(1988, 12, 1))
     spy = mocker.spy(pop.hiv_status, "introduce_HIV")
@@ -62,6 +62,17 @@ def test_HIV_introduced_only_once(mocker):
     # ...but should not be repeated at the next time step
     pop.evolve(timedelta(days=31))
     spy.assert_called_once()
+
+
+def test_hiv_not_reintroduced_after_1989(mocker):
+    """Check that we do not initialise HIV status repeatedly."""
+    pop = Population(size=1000, start_date=date(1989, 4, 1))
+    assert pop.HIV_introduced
+    # HIV has been introduced, so that should not be called again
+    spy = mocker.spy(pop.hiv_status, "introduce_HIV")
+    for _ in range(10):
+        pop.evolve(timedelta(days=31))
+    spy.assert_not_called()
 
 
 def test_hiv_initial_ages(pop_with_initial_hiv):

--- a/src/tests/test_hiv_status.py
+++ b/src/tests/test_hiv_status.py
@@ -10,6 +10,16 @@ from hivpy.population import Population
 from hivpy.sexual_behaviour import selector
 
 
+@pytest.fixture
+def pop_with_hiv():
+    pop_size = 100000
+    pop = Population(size=pop_size, start_date=date(1989, 1, 1))
+    # Wait a few months so more people are positive
+    for _ in range(5):
+        pop.evolve(timedelta(days=30))
+    return pop
+
+
 def test_initial_hiv_threshold():
     """Check that HIV is initially introduced only to those with high enough newp."""
     pop = Population(size=1000, start_date=date(1989, 1, 1)).data
@@ -46,15 +56,13 @@ def test_HIV_introduced_only_once(mocker):
     spy.assert_called_once()
 
 
-def test_hiv_update():
+def test_hiv_update(pop_with_hiv):
     pd.set_option('display.max_columns', None)
-    pop_size = 100000
-    pop = Population(size=pop_size, start_date=date(1989, 1, 1))
-    data = pop.data
+    data = pop_with_hiv.data
     prev_status = data["HIV_status"].copy()
 
     for i in range(10):
-        pop.hiv_status.update_HIV_status(pop.data)
+        pop_with_hiv.hiv_status.update_HIV_status(pop_with_hiv.data)
 
     new_cases = data["HIV_status"] & (~ prev_status)
     miracles = (~ data["HIV_status"]) & (prev_status)

--- a/src/tests/test_hiv_status.py
+++ b/src/tests/test_hiv_status.py
@@ -78,7 +78,7 @@ def test_hiv_update(pop_with_hiv):
     data = pop_with_hiv.data
     prev_status = data["HIV_status"].copy()
 
-    for i in range(100):
+    for i in range(10):
         pop_with_hiv.hiv_status.update_HIV_status(pop_with_hiv.data)
 
     new_cases = data["HIV_status"] & (~ prev_status)

--- a/src/tests/test_hiv_status.py
+++ b/src/tests/test_hiv_status.py
@@ -1,5 +1,5 @@
 import operator
-from datetime import date
+from datetime import date, timedelta
 
 import pandas as pd
 import pytest
@@ -30,6 +30,20 @@ def test_initial_hiv_probability():
     initial_status = HIV_module.introduce_HIV(pop)
     # TODO Could check against variance of binomial distribution, see issue #45
     assert initial_status.sum() == pytest.approx(expected_infections, rel=0.05)
+
+
+def test_HIV_introduced_only_once(mocker):
+    """Check that we do not initialise HIV status repeatedly."""
+    pop = Population(size=1000, start_date=date(1988, 12, 1))
+    spy = mocker.spy(pop.hiv_status, "introduce_HIV")
+    pop.evolve(timedelta(days=31))
+    spy.assert_not_called()
+    # Starting from 1989/1/1, so HIV should now be introduced...
+    pop.evolve(timedelta(days=31))
+    spy.assert_called_once()
+    # ...but should not be repeated at the next time step
+    pop.evolve(timedelta(days=31))
+    spy.assert_called_once()
 
 
 def test_hiv_update():


### PR DESCRIPTION
Resolves #63.

I'm not sure whether the "starting" date is better placed in the population or the HIV status module (or somewhere else).

I've adjusted the transmission rate to make the test more reliable, but that part will be overwritten anyway (#62).

One thing to check: in the SAS model, this occurs in "year" 1989.25, which would be April 1, not January 1. Does this make a difference in this implementation (if we start a simulation on January 1)? Or are all the variables set up for it?