### PR TITLE
Basic template for Sphinx

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,6 @@ output/
 *.egg
 __pycache__/
 .pytest_cache/
+
+# Generated documentation
+_build

--- a/setup.cfg
+++ b/setup.cfg
@@ -36,6 +36,7 @@ tests =
     pytest
     flake8
     isort
+    sphinx
 
 [options.entry_points]
 console_scripts =

--- a/src/docs/Makefile
+++ b/src/docs/Makefile
@@ -1,0 +1,20 @@
+# Minimal makefile for Sphinx documentation
+#
+
+# You can set these variables from the command line, and also
+# from the environment for the first two.
+SPHINXOPTS    ?=
+SPHINXBUILD   ?= sphinx-build
+SOURCEDIR     = .
+BUILDDIR      = _build
+
+# Put it first so that "make" without argument is like "make help".
+help:
+	@$(SPHINXBUILD) -M help "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
+
+.PHONY: help Makefile
+
+# Catch-all target: route all unknown targets to Sphinx using the new
+# "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).
+%: Makefile
+	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)

--- a/src/docs/conf.py
+++ b/src/docs/conf.py
@@ -1,0 +1,29 @@
+# Configuration file for the Sphinx documentation builder.
+#
+# For the full list of built-in configuration values, see the documentation:
+# https://www.sphinx-doc.org/en/master/usage/configuration.html
+import sys
+
+sys.path.insert(0, '..')  # To find the package code
+
+# -- Project information -----------------------------------------------------
+# https://www.sphinx-doc.org/en/master/usage/configuration.html#project-information
+
+project = 'HIVpy'
+copyright = '2022, UCL'
+author = 'UCL'
+
+# -- General configuration ---------------------------------------------------
+# https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration
+
+extensions = ["sphinx.ext.autodoc"]
+
+templates_path = ['_templates']
+exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store']
+
+
+# -- Options for HTML output -------------------------------------------------
+# https://www.sphinx-doc.org/en/master/usage/configuration.html#options-for-html-output
+
+html_theme = 'alabaster'
+html_static_path = ['_static']

--- a/src/docs/hivpy.cli.rst
+++ b/src/docs/hivpy.cli.rst
@@ -1,0 +1,7 @@
+hivpy.cli module
+================
+
+.. automodule:: hivpy.cli
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/src/docs/hivpy.column_names.rst
+++ b/src/docs/hivpy.column_names.rst
@@ -1,0 +1,7 @@
+hivpy.column\_names module
+==========================
+
+.. automodule:: hivpy.column_names
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/src/docs/hivpy.common.rst
+++ b/src/docs/hivpy.common.rst
@@ -1,0 +1,7 @@
+hivpy.common module
+===================
+
+.. automodule:: hivpy.common
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/src/docs/hivpy.config.rst
+++ b/src/docs/hivpy.config.rst
@@ -1,0 +1,7 @@
+hivpy.config module
+===================
+
+.. automodule:: hivpy.config
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/src/docs/hivpy.data.rst
+++ b/src/docs/hivpy.data.rst
@@ -1,0 +1,10 @@
+hivpy.data package
+==================
+
+Module contents
+---------------
+
+.. automodule:: hivpy.data
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/src/docs/hivpy.demographics.rst
+++ b/src/docs/hivpy.demographics.rst
@@ -1,0 +1,7 @@
+hivpy.demographics module
+=========================
+
+.. automodule:: hivpy.demographics
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/src/docs/hivpy.demographics_data.rst
+++ b/src/docs/hivpy.demographics_data.rst
@@ -1,0 +1,7 @@
+hivpy.demographics\_data module
+===============================
+
+.. automodule:: hivpy.demographics_data
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/src/docs/hivpy.exceptions.rst
+++ b/src/docs/hivpy.exceptions.rst
@@ -1,0 +1,7 @@
+hivpy.exceptions module
+=======================
+
+.. automodule:: hivpy.exceptions
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/src/docs/hivpy.experiment.rst
+++ b/src/docs/hivpy.experiment.rst
@@ -1,0 +1,7 @@
+hivpy.experiment module
+=======================
+
+.. automodule:: hivpy.experiment
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/src/docs/hivpy.hiv_status.rst
+++ b/src/docs/hivpy.hiv_status.rst
@@ -1,0 +1,7 @@
+hivpy.hiv\_status module
+========================
+
+.. automodule:: hivpy.hiv_status
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/src/docs/hivpy.population.rst
+++ b/src/docs/hivpy.population.rst
@@ -1,0 +1,7 @@
+hivpy.population module
+=======================
+
+.. automodule:: hivpy.population
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/src/docs/hivpy.rst
+++ b/src/docs/hivpy.rst
@@ -1,0 +1,38 @@
+hivpy package
+=============
+
+Subpackages
+-----------
+
+.. toctree::
+   :maxdepth: 4
+
+   hivpy.data
+
+Submodules
+----------
+
+.. toctree::
+   :maxdepth: 4
+
+   hivpy.cli
+   hivpy.column_names
+   hivpy.common
+   hivpy.config
+   hivpy.demographics
+   hivpy.demographics_data
+   hivpy.exceptions
+   hivpy.experiment
+   hivpy.hiv_status
+   hivpy.population
+   hivpy.sex_behaviour_data
+   hivpy.sexual_behaviour
+   hivpy.simulation
+
+Module contents
+---------------
+
+.. automodule:: hivpy
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/src/docs/hivpy.sex_behaviour_data.rst
+++ b/src/docs/hivpy.sex_behaviour_data.rst
@@ -1,0 +1,7 @@
+hivpy.sex\_behaviour\_data module
+=================================
+
+.. automodule:: hivpy.sex_behaviour_data
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/src/docs/hivpy.sexual_behaviour.rst
+++ b/src/docs/hivpy.sexual_behaviour.rst
@@ -1,0 +1,7 @@
+hivpy.sexual\_behaviour module
+==============================
+
+.. automodule:: hivpy.sexual_behaviour
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/src/docs/hivpy.simulation.rst
+++ b/src/docs/hivpy.simulation.rst
@@ -1,0 +1,7 @@
+hivpy.simulation module
+=======================
+
+.. automodule:: hivpy.simulation
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/src/docs/index.rst
+++ b/src/docs/index.rst
@@ -1,0 +1,23 @@
+.. HIVpy documentation master file, created by
+   sphinx-quickstart on Wed Oct  5 23:51:08 2022.
+   You can adapt this file completely to your liking, but it should at least
+   contain the root `toctree` directive.
+
+Welcome to HIVpy's documentation!
+=================================
+
+This code simulates a model of the spread and effects of HIV in Sub-Saharan Africa.
+
+.. toctree::
+   :maxdepth: 2
+   :caption: Contents:
+   
+   modules
+
+
+Indices and tables
+==================
+
+* :ref:`genindex`
+* :ref:`modindex`
+* :ref:`search`

--- a/src/docs/make.bat
+++ b/src/docs/make.bat
@@ -1,0 +1,35 @@
+@ECHO OFF
+
+pushd %~dp0
+
+REM Command file for Sphinx documentation
+
+if "%SPHINXBUILD%" == "" (
+	set SPHINXBUILD=sphinx-build
+)
+set SOURCEDIR=.
+set BUILDDIR=_build
+
+%SPHINXBUILD% >NUL 2>NUL
+if errorlevel 9009 (
+	echo.
+	echo.The 'sphinx-build' command was not found. Make sure you have Sphinx
+	echo.installed, then set the SPHINXBUILD environment variable to point
+	echo.to the full path of the 'sphinx-build' executable. Alternatively you
+	echo.may add the Sphinx directory to PATH.
+	echo.
+	echo.If you don't have Sphinx installed, grab it from
+	echo.https://www.sphinx-doc.org/
+	exit /b 1
+)
+
+if "%1" == "" goto help
+
+%SPHINXBUILD% -M %1 %SOURCEDIR% %BUILDDIR% %SPHINXOPTS% %O%
+goto end
+
+:help
+%SPHINXBUILD% -M help %SOURCEDIR% %BUILDDIR% %SPHINXOPTS% %O%
+
+:end
+popd

--- a/src/docs/modules.rst
+++ b/src/docs/modules.rst
@@ -1,0 +1,7 @@
+hivpy
+=====
+
+.. toctree::
+   :maxdepth: 4
+
+   hivpy


### PR DESCRIPTION
Including new files created with `sphinx-quickstart` and `sphinx-apidoc`, with some changes. Also adding new dependency for sphinx for the "development" install (which we should perhaps rename from `tests`).

Docs can be built by running `make html` from the `src/docs` directory. The created pages are then in `src/docs/_build`.

If someone can verify that this works, we can add further documentation (either in the code or in the docs pages themselves) in separate PRs.