### PR TITLE
Add more descriptive logical expressions for dataframe

### DIFF
--- a/src/hivpy/common.py
+++ b/src/hivpy/common.py
@@ -146,10 +146,10 @@ class LogicExpr(ABC):
     """
     Abstract class for representing general logical expressions as applied to a population.
     Derived classes are: COND for individual conditions (e.g. age > 15)
-                         AND for conjunctions 
+                         AND for conjunctions
                          OR for disjunctions
     AND and OR can take a list of LogicExpr which may be of any of the three types to
-    give full freedom to create any logical statement without being beholden to e.g. 
+    give full freedom to create any logical statement without being beholden to e.g.
     conjunctive normal form.
     """
     @abstractmethod
@@ -164,7 +164,7 @@ class COND(LogicExpr):
     var: The variable you want to check as a dataframe column e.g. col.AGE
     op: The operator you want to apply, such as op.eq, op.le, op.gt etc.
     val: The value you want to compare the variable to
-    As an example, expressing "age > 15" would be 
+    As an example, expressing "age > 15" would be
     COND(col.AGE, op.gt, 15)
     """
     def __init__(self, var, op, val):

--- a/src/hivpy/common.py
+++ b/src/hivpy/common.py
@@ -13,6 +13,7 @@ import operator
 from abc import ABC, abstractmethod
 from contextlib import contextmanager
 from enum import IntEnum
+from functools import reduce
 
 import numpy as np
 import scipy.stats as stat

--- a/src/hivpy/population.py
+++ b/src/hivpy/population.py
@@ -149,7 +149,7 @@ class Population:
         """
         Evaluate a disjunction so that is can be used in CNF expressions.
         """
-        if type(expr) == list:
+        if isinstance(expr, list):
             return reduce(operator.or_,
                           (self.eval(sub_expr)
                            for sub_expr in expr))

--- a/src/hivpy/population.py
+++ b/src/hivpy/population.py
@@ -7,6 +7,7 @@ import pandas as pd
 import hivpy.column_names as col
 
 from .circumcision import CircumcisionModule
+from .common import LogicExpr
 from .demographics import DemographicsModule
 from .hiv_status import HIVStatusModule
 from .hiv_testing import HIVTestingModule
@@ -142,10 +143,15 @@ class Population:
         e.g. `(col.AGE, operator.ge, 15)` gets people who are 15 and over\\
         `conditions` is a list (or other iterable) of such tuples.
         """
-        index = reduce(operator.and_,
-                       (self.disjunction(expr)
-                        for expr in conditions))
-        return self.data.index[index]
+        # if / else statements here for backwards compatibility
+        # (Python doesn't allow overloaded functions)
+        if (isinstance(conditions, LogicExpr)):
+            return self.data.index[conditions.eval(self)]
+        else:
+            index = reduce(operator.and_,
+                           (self.disjunction(expr)
+                            for expr in conditions))
+            return self.data.index[index]
 
     def disjunction(self, expr):
         """

--- a/src/hivpy/sexual_behaviour.py
+++ b/src/hivpy/sexual_behaviour.py
@@ -11,7 +11,7 @@ import pandas as pd
 
 import hivpy.column_names as col
 
-from .common import SexType, diff_years, rng
+from .common import AND, COND, SexType, diff_years, rng
 from .sex_behaviour_data import SexualBehaviourData
 
 if TYPE_CHECKING:
@@ -186,9 +186,12 @@ class SexualBehaviourModule:
     def init_sex_worker_status(self, population: Population):
         # For life sex risk to be set this has to come after risk factors init
         # Only women will be sex workers
-        female_15to49 = population.get_sub_pop([(col.SEX, operator.eq, SexType.Female),
-                                                (col.AGE, operator.ge, 15),
-                                                (col.AGE, operator.lt, 50)])
+        # female_15to49 = population.get_sub_pop([(col.SEX, operator.eq, SexType.Female),
+        #                                         (col.AGE, operator.ge, 15),
+        #                                         (col.AGE, operator.lt, 50)])
+        female_15to49 = population.get_sub_pop(AND(COND(col.SEX, operator.eq, SexType.Female),
+                                                   COND(col.AGE, operator.ge, 15),
+                                                   COND(col.AGE, operator.lt, 50)))
 
         def initial_sex_worker(age_group, life_sex_risk, size):
             if (life_sex_risk == 1):

--- a/src/tests/test_population.py
+++ b/src/tests/test_population.py
@@ -1,7 +1,11 @@
 from datetime import date
+import numpy as np 
 
 from hivpy import column_names as col
 from hivpy.population import Population
+from hivpy.common import SexType
+from hivpy.common import COND, AND, OR
+import operator as op
 
 
 def test_population_init():
@@ -9,3 +13,39 @@ def test_population_init():
     print(pop)
     assert (len(pop.data) == 100)
     assert ((col.HIV_STATUS) in pop.data.columns)
+
+def test_COND():
+    pop = Population(size=1000, start_date=date(1989, 1, 1))
+    pop.data[col.SEX] = np.array([SexType.Male, SexType.Female] * 500)
+    males = pop.get_sub_pop(COND(col.SEX, op.eq, SexType.Male))
+    females = pop.get_sub_pop(COND(col.SEX, op.ne, SexType.Male))  # check different operator
+    assert (len(males) == 500)
+    assert (len(females) == 500)
+    assert (SexType.Female not in pop.get_variable(col.SEX, males))
+    assert all(pop.get_variable(col.SEX, females) == SexType.Female)
+    
+    # test returning empty
+    pop.data[col.SEX] = SexType.Male
+    females = pop.get_sub_pop(COND(col.SEX, op.ne, SexType.Male))
+    assert (len(females) == 0)
+
+def test_AND():
+    pop = Population(size=1000, start_date=date(1989, 1, 1))
+    pop.data[col.SEX] = np.concatenate((np.array([SexType.Male] * 500), np.array([SexType.Female] * 500)))
+    pop.data[col.AGE] = np.array([10,20,30,40] * 250)
+    female_over_15 = pop.get_sub_pop(AND(COND(col.SEX, op.eq, SexType.Female),
+                                         COND(col.AGE, op.ge, 15)))
+    assert(len(female_over_15) == 375)
+    assert all(pop.get_variable(col.AGE, female_over_15) >= 15)
+    assert all(pop.get_variable(col.SEX, female_over_15) == SexType.Female)
+
+    male_over_15_under_40 = pop.get_sub_pop(AND(COND(col.SEX, op.eq, SexType.Male),
+                                                COND(col.AGE, op.ge, 15),
+                                                COND(col.AGE, op.lt, 40)))
+    assert(len(male_over_15_under_40) == 250)
+    assert all(pop.get_variable(col.AGE, male_over_15_under_40) >= 15)
+    assert all(pop.get_variable(col.AGE, male_over_15_under_40) < 40)
+    assert all(pop.get_variable(col.SEX, male_over_15_under_40) == SexType.Male)
+
+def test_OR():
+    

--- a/src/tests/test_population.py
+++ b/src/tests/test_population.py
@@ -1,11 +1,11 @@
+import operator as op
 from datetime import date
-import numpy as np 
+
+import numpy as np
 
 from hivpy import column_names as col
+from hivpy.common import AND, COND, OR, SexType
 from hivpy.population import Population
-from hivpy.common import SexType
-from hivpy.common import COND, AND, OR
-import operator as op
 
 
 def test_population_init():
@@ -13,6 +13,7 @@ def test_population_init():
     print(pop)
     assert (len(pop.data) == 100)
     assert ((col.HIV_STATUS) in pop.data.columns)
+
 
 def test_COND():
     pop = Population(size=1000, start_date=date(1989, 1, 1))
@@ -23,61 +24,65 @@ def test_COND():
     assert (len(females) == 500)
     assert (SexType.Female not in pop.get_variable(col.SEX, males))
     assert all(pop.get_variable(col.SEX, females) == SexType.Female)
-    
+
     # test returning empty
     pop.data[col.SEX] = SexType.Male
     females = pop.get_sub_pop(COND(col.SEX, op.ne, SexType.Male))
     assert (len(females) == 0)
 
+
 def test_AND():
     pop = Population(size=1000, start_date=date(1989, 1, 1))
     pop.data[col.SEX] = np.concatenate((np.array([SexType.Male] * 500), np.array([SexType.Female] * 500)))
-    pop.data[col.AGE] = np.array([10,20,30,40] * 250)
+    pop.data[col.AGE] = np.array([10, 20, 30, 40] * 250)
     female_over_15 = pop.get_sub_pop(AND(COND(col.SEX, op.eq, SexType.Female),
                                          COND(col.AGE, op.ge, 15)))
-    assert(len(female_over_15) == 375)
+    assert (len(female_over_15) == 375)
     assert all(pop.get_variable(col.AGE, female_over_15) >= 15)
     assert all(pop.get_variable(col.SEX, female_over_15) == SexType.Female)
 
     male_over_15_under_40 = pop.get_sub_pop(AND(COND(col.SEX, op.eq, SexType.Male),
                                                 COND(col.AGE, op.ge, 15),
                                                 COND(col.AGE, op.lt, 40)))
-    assert(len(male_over_15_under_40) == 250)
+    assert (len(male_over_15_under_40) == 250)
     assert all(pop.get_variable(col.AGE, male_over_15_under_40) >= 15)
     assert all(pop.get_variable(col.AGE, male_over_15_under_40) < 40)
     assert all(pop.get_variable(col.SEX, male_over_15_under_40) == SexType.Male)
 
     # test AND with only one argument
     male_pop = pop.get_sub_pop(AND(COND(col.SEX, op.eq, SexType.Male)))
-    assert(len(male_pop) == 500)
+    assert (len(male_pop) == 500)
     assert all(pop.get_variable(col.SEX, male_pop) == SexType.Male)
+
 
 def test_OR():
     pop = Population(size=1500, start_date=date(1989, 1, 1))
     pop.data[col.SEX] = np.concatenate((np.array([SexType.Male] * 750), np.array([SexType.Female] * 750)))
-    pop.data[col.AGE] = np.array([10,20,30,40,60,80] * 250)
+    pop.data[col.AGE] = np.array([10, 20, 30, 40, 60, 80] * 250)
     women_or_children = pop.get_sub_pop(OR(COND(col.SEX, op.eq, SexType.Female),
                                            COND(col.AGE, op.lt, 18)))
-    assert(len(women_or_children) == 875)
-    assert all((pop.get_variable(col.AGE, women_or_children) <= 18) | (pop.get_variable(col.SEX, women_or_children) == SexType.Female))
+    assert (len(women_or_children) == 875)
+    assert all((pop.get_variable(col.AGE, women_or_children) <= 18) |
+               (pop.get_variable(col.SEX, women_or_children) == SexType.Female))
 
     women_or_children_or_elderly = pop.get_sub_pop(OR(COND(col.SEX, op.eq, SexType.Female),
                                                       COND(col.AGE, op.lt, 18),
                                                       COND(col.AGE, op.ge, 65)))
-    assert(len(women_or_children_or_elderly) == 1000)
+    assert (len(women_or_children_or_elderly) == 1000)
     ages = pop.get_variable(col.AGE, women_or_children_or_elderly)
     sexes = pop.get_variable(col.SEX, women_or_children_or_elderly)
-    assert all ((sexes == SexType.Female) | (ages < 18) | (ages >= 65) ) 
+    assert all((sexes == SexType.Female) | (ages < 18) | (ages >= 65))
 
     # test OR with only one argument
     male_pop = pop.get_sub_pop(OR(COND(col.SEX, op.eq, SexType.Male)))
-    assert(len(male_pop) == 750)
+    assert (len(male_pop) == 750)
     assert all(pop.get_variable(col.SEX, male_pop) == SexType.Male)
+
 
 def test_compound_expression():
     pop = Population(size=1000, start_date=date(1989, 1, 1))
     pop.data[col.SEX] = np.concatenate((np.array([SexType.Male] * 500), np.array([SexType.Female] * 500)))
-    pop.data[col.AGE] = np.array([10,20,30,40] * 250)
+    pop.data[col.AGE] = np.array([10, 20, 30, 40] * 250)
     female_over_25_or_male_under_25 = pop.get_sub_pop(
         OR(
             AND(
@@ -90,8 +95,8 @@ def test_compound_expression():
             )
         )
     )
-    assert(len(female_over_25_or_male_under_25) == 500)
+    assert (len(female_over_25_or_male_under_25) == 500)
     ages = pop.get_variable(col.AGE, female_over_25_or_male_under_25)
     sexes = pop.get_variable(col.SEX, female_over_25_or_male_under_25)
-    assert all( (ages < 25) | (sexes == SexType.Female) )
-    assert all( (ages > 25) | (sexes == SexType.Male) )
+    assert all((ages < 25) | (sexes == SexType.Female))
+    assert all((ages > 25) | (sexes == SexType.Male))

--- a/src/tests/test_population.py
+++ b/src/tests/test_population.py
@@ -47,5 +47,51 @@ def test_AND():
     assert all(pop.get_variable(col.AGE, male_over_15_under_40) < 40)
     assert all(pop.get_variable(col.SEX, male_over_15_under_40) == SexType.Male)
 
+    # test AND with only one argument
+    male_pop = pop.get_sub_pop(AND(COND(col.SEX, op.eq, SexType.Male)))
+    assert(len(male_pop) == 500)
+    assert all(pop.get_variable(col.SEX, male_pop) == SexType.Male)
+
 def test_OR():
-    
+    pop = Population(size=1500, start_date=date(1989, 1, 1))
+    pop.data[col.SEX] = np.concatenate((np.array([SexType.Male] * 750), np.array([SexType.Female] * 750)))
+    pop.data[col.AGE] = np.array([10,20,30,40,60,80] * 250)
+    women_or_children = pop.get_sub_pop(OR(COND(col.SEX, op.eq, SexType.Female),
+                                           COND(col.AGE, op.lt, 18)))
+    assert(len(women_or_children) == 875)
+    assert all((pop.get_variable(col.AGE, women_or_children) <= 18) | (pop.get_variable(col.SEX, women_or_children) == SexType.Female))
+
+    women_or_children_or_elderly = pop.get_sub_pop(OR(COND(col.SEX, op.eq, SexType.Female),
+                                                      COND(col.AGE, op.lt, 18),
+                                                      COND(col.AGE, op.ge, 65)))
+    assert(len(women_or_children_or_elderly) == 1000)
+    ages = pop.get_variable(col.AGE, women_or_children_or_elderly)
+    sexes = pop.get_variable(col.SEX, women_or_children_or_elderly)
+    assert all ((sexes == SexType.Female) | (ages < 18) | (ages >= 65) ) 
+
+    # test OR with only one argument
+    male_pop = pop.get_sub_pop(OR(COND(col.SEX, op.eq, SexType.Male)))
+    assert(len(male_pop) == 750)
+    assert all(pop.get_variable(col.SEX, male_pop) == SexType.Male)
+
+def test_compound_expression():
+    pop = Population(size=1000, start_date=date(1989, 1, 1))
+    pop.data[col.SEX] = np.concatenate((np.array([SexType.Male] * 500), np.array([SexType.Female] * 500)))
+    pop.data[col.AGE] = np.array([10,20,30,40] * 250)
+    female_over_25_or_male_under_25 = pop.get_sub_pop(
+        OR(
+            AND(
+                COND(col.SEX, op.eq, SexType.Female),
+                COND(col.AGE, op.ge, 25)
+            ),
+            AND(
+                COND(col.SEX, op.eq, SexType.Male),
+                COND(col.AGE, op.lt, 25)
+            )
+        )
+    )
+    assert(len(female_over_25_or_male_under_25) == 500)
+    ages = pop.get_variable(col.AGE, female_over_25_or_male_under_25)
+    sexes = pop.get_variable(col.SEX, female_over_25_or_male_under_25)
+    assert all( (ages < 25) | (sexes == SexType.Female) )
+    assert all( (ages > 25) | (sexes == SexType.Male) )


### PR DESCRIPTION
Instead of using the unannotated lists to create a statement which is implicitly in conjunctive normal form (which is admittedly a touch confusing!), this gives the option of writing logic expressions for e.g. `get_sub_pop` using three kinds of statements:
-  `COND`: for a single condition e.g. `COND(col.AGE, op.gt, 30)`
- `AND`: for a list of conjunctions which are just given as an abritrary list of expressions in the arguments to the constructor e.g. `AND(expr1, expr2, expr3...). No `[]` lists required!
- `OR`: same as `AND` but for disjunctions. 

It's slightly more verbose by virtue of writing `COND`/`AND`/`OR` but more clearer what is going on, and doesn't require you to parse out the `([(...` stuff that we have with the current system of tuples inside lists inside ... 

**Still needs some tests to be written.** 

You can see an example of how to use this framework in the change to sexual_behaviour, but I've temporarily left the old code in as a comment to make the comparison easier to see if you checkout the code. 