### PR TITLE
Avoid numpy breaking ABI changes for now

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -18,7 +18,7 @@ packages = find:
 python_requires = >=3.7
 install_requires =
     pandas<1.4
-    numpy
+    numpy<2.0.0
     scipy
     pyyaml
     matplotlib


### PR DESCRIPTION
Numpy 2.0.0 has just been released and introduces breaking changes to the ABI. This means that precompiled packages like scipy and pandas will break if used with the new numpy. So for now we will need to avoid it until the other packages catch up and we can potentially upgrade everything. 